### PR TITLE
Added Internet permission in AndroidManifext.xml template

### DIFF
--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -48,6 +48,7 @@ String _androidNewMainMinfest(String domain,String projectname) => '''
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="$projectname"


### PR DESCRIPTION
By default, debug mode has Internet permission tag in manifest file but on release mode it is not there. So, In AndroidManifest.xml template I have added required permission tag.