### PR TITLE
Updated dependency versions and added new WEB features

### DIFF
--- a/bin/create.dart
+++ b/bin/create.dart
@@ -1,9 +1,17 @@
+import 'package:args/args.dart';
 import 'package:animated_native_splash/animated_native_splash.dart'
     as animated_native_splash;
 import 'package:animated_native_splash/supported_platform.dart'
     as animated_native_splash_supported_platform;
 
 void main(List<String> arguments) {
+  final parser = ArgParser();
+
+  parser.addOption('path');
+  final parsedArgs = parser.parse(arguments);
+
   print(animated_native_splash_supported_platform.introMessage('1.3.0'));
-  animated_native_splash.createSplash();
+  animated_native_splash.createSplash(
+    path: parsedArgs['path']?.toString(),
+  );
 }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -32,7 +32,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,77 +7,87 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.4.10"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: "1989d917fbe8e6b39806207df5a3fdd3d816cbd090fac2ce26fb45e9a71476e5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,7 +97,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -99,44 +110,74 @@ packages:
     dependency: transitive
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.1.7"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.16"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.3"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "6.0.2"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -146,78 +187,97 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   universal_io:
     dependency: transitive
     description:
       name: universal_io
-      url: "https://pub.dartlang.org"
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
     source: hosted
-    version: "5.3.1"
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -16,6 +16,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.10"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
   async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -100,3 +100,4 @@ animated_native_splash:
     loop: true
     fadeOut: true
     fadeOutDuration: 3
+    backgroundColor: "#ffffff"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -93,5 +93,10 @@ flutter:
 animated_native_splash:
   # color is the only required parameter.  It sets the background color of your splash screen.
   jsonFile: assets/loading.json
-  android: true
-  web: true
+  android:
+    enabled: true
+  web:
+    enabled: true
+    loop: true
+    fadeOut: true
+    fadeOutDuration: 3

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -93,3 +93,5 @@ flutter:
 animated_native_splash:
   # color is the only required parameter.  It sets the background color of your splash screen.
   jsonFile: assets/loading.json
+  android: true
+  web: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -101,3 +101,6 @@ animated_native_splash:
     fadeOut: true
     fadeOutDuration: 3
     backgroundColor: "#ffffff"
+    height: 200
+    width: 200
+

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -25,13 +25,22 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="example" />
     <link rel="apple-touch-icon" href="icons/Icon-192.png" />
+
     <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+    
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="favicon.png" />
 
-    <title>example</title>
+    <title></title>
     <link rel="stylesheet" href="splash/style.css" />
     <link rel="manifest" href="manifest.json" />
+
+    <script>
+      // The value below is injected by flutter build, do not touch.
+      const serviceWorkerVersion = null;
+    </script>
+    <!-- This script adds the flutter initialization JS code -->
+    <script src="flutter.js" defer></script>
   </head>
   <body>
     <div id="preloader" class="preloader-container">
@@ -42,7 +51,6 @@
             background="transparent"
             speed="1"
             style="width: 400px; height: 400px"
-            loop
             autoplay
           ></lottie-player>
         </div>
@@ -52,20 +60,21 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
     <script>
-      var serviceWorkerVersion = null;
-      var scriptLoaded = false;
-      function loadMainDartJs() {
-        if (scriptLoaded) {
-          return;
-        }
-        scriptLoaded = true;
-        var scriptTag = document.createElement("script");
-        scriptTag.src = "main.dart.js";
-        scriptTag.type = "application/javascript";
-        document.body.append(scriptTag);
-      }
+      var isInitialized = false
+      var isCompleted = false
       let box = document.querySelector("#preloader");
-      function fadeOut() {
+      const animation = document.querySelector("lottie-player");
+
+      animation.addEventListener("complete", () => {
+        isCompleted = true
+        checkSplashAnimation()
+      });
+      animation.addEventListener("loop", () => {
+        isCompleted = true
+        checkSplashAnimation()
+      });
+
+      function fadeOutSplashAnimation() {
         box.classList.add("visuallyhidden");
         box.addEventListener(
           "transitionend",
@@ -80,57 +89,36 @@
         );
       }
 
-      if ("serviceWorker" in navigator) {
-        // Service workers are supported. Use them.
-        window.addEventListener("load", function () {
-          // Wait for registration to finish before dropping the <script> tag.
-          // Otherwise, the browser will load the script multiple times,
-          // potentially different versions.
-          var serviceWorkerUrl =
-            "flutter_service_worker.js?v=" + serviceWorkerVersion;
-          navigator.serviceWorker.register(serviceWorkerUrl).then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener("statechange", () => {
-                if (serviceWorker.state == "activated") {
-                  console.log("Installed new service worker.");
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log("New service worker available.");
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              //fadeOut();
-              // Existing service worker is still good.
-              console.log("Loading app from service worker.");
-              loadMainDartJs();
-            }
-          });
-          setTimeout(fadeOut, 3000);
-          // If service worker doesn't succeed in a reasonable amount of time,
-          // fallback to plaint <script> tag.
-          setTimeout(() => {
-            if (!scriptLoaded) {
-              console.warn(
-                "Failed to load app from service worker. Falling back to plain <script> tag."
-              );
-              loadMainDartJs();
-            }
-          }, 4000);
-        });
-      } else {
-        fadeOut();
-        // Service workers not supported. Just drop the <script> tag.
-        loadMainDartJs();
+      function removeSplashAnimation() {
+        box.classList.add("hidden");
       }
+
+      function checkSplashAnimation() {
+        if(!isCompleted) {
+          return;
+        }
+        if(!isInitialized) {
+          return;
+        }
+        fadeOutSplashAnimation(); 
+      }
+
+      window.addEventListener('load', function(ev) {
+      // Download main.dart.js
+      _flutter.loader.loadEntrypoint({
+        serviceWorker: {
+          serviceWorkerVersion: serviceWorkerVersion,
+        },
+        onEntrypointLoaded: function(engineInitializer) {
+
+          engineInitializer.initializeEngine().then(async function(appRunner) {
+            await appRunner.runApp();
+            isInitialized = true
+            checkSplashAnimation();
+          });
+        }
+      });
+    });
     </script>
   </body>
 </html>

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -31,7 +31,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="favicon.png" />
 
-    <title></title>
+    <title>example</title>
     <link rel="stylesheet" href="splash/style.css" />
     <link rel="manifest" href="manifest.json" />
 
@@ -50,7 +50,8 @@
             src="splash/splash.json"
             background="transparent"
             speed="1"
-            style="width: 400px; height: 400px"
+            style="width: 200px; height: 200px"
+loop
             autoplay
           ></lottie-player>
         </div>

--- a/example/web/splash/style.css
+++ b/example/web/splash/style.css
@@ -10,7 +10,7 @@
 	display: -webkit-box;
 	display: -ms-flexbox;
 	display: flex;
-	background-color: #f1f1f2;
+	background-color: #ffffff;
 	-webkit-box-pack: center;
 	-ms-flex-pack: center;
 	justify-content: center;
@@ -18,9 +18,9 @@
 	-ms-flex-align: center;
 	align-items: center;
 	overflow: hidden;
-	-webkit-transition: all 1s linear;
-	-o-transition: all 1s linear;
-	transition: all 1s linear;
+	-webkit-transition: all 10s linear;
+	-o-transition: all 10s linear;
+	transition: all 10s linear;
 }
 
 .preloader-container .animation {

--- a/example/web/splash/style.css
+++ b/example/web/splash/style.css
@@ -18,9 +18,9 @@
 	-ms-flex-align: center;
 	align-items: center;
 	overflow: hidden;
-	-webkit-transition: all 10s linear;
-	-o-transition: all 10s linear;
-	transition: all 10s linear;
+	-webkit-transition: all 3s linear;
+	-o-transition: all 3s linear;
+	transition: all 3s linear;
 }
 
 .preloader-container .animation {

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -1,4 +1,4 @@
-part of animated_native_splash_supported_platform;
+part of 'supported_platform.dart';
 
 /// Create Android splash screen
 ///

--- a/lib/animated_native_splash.dart
+++ b/lib/animated_native_splash.dart
@@ -13,8 +13,10 @@ import 'unsupported_platform.dart' // Stub implementation
     if (dart.library.io) 'supported_platform.dart'; // dart:io implementation
 
 /// Create splash screens for Android and iOS
-Future<void> createSplash() async {
-  await tryCreateSplash();
+Future<void> createSplash({
+  required String? path,
+}) async {
+  await tryCreateSplash(path: path);
 }
 
 /// Create splash screens for Android and iOS based on a config argument

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,4 +1,4 @@
-part of animated_native_splash_supported_platform;
+part of 'supported_platform.dart';
 
 // Android-related constants
 /// Below is all the const path needed to inject our files and comnunicate with the android project
@@ -18,8 +18,7 @@ String _androidMainActivityKitFile(
         String domain, String company, String appname) =>
     'android/app/src/main/kotlin/$domain/$company/$appname/MainActivity.kt';
 String applicationName = '\${applicationName}';
-String introMessage(String currentVersion) =>
-    '''
+String introMessage(String currentVersion) => '''
   ════════════════════════════════════════════
    🎈ANIMATED NATIVE SPLASH (v$currentVersion)
   ════════════════════════════════════════════
@@ -27,7 +26,7 @@ String introMessage(String currentVersion) =>
 
 ///Web
 const String _webFolder = 'web/';
-const String _webIndex = _webFolder + 'index.html';
+const String _webIndex = '${_webFolder}index.html';
 const String _webRelativeStyleFile = 'web/splash/style.css';
 const String _splashFile = 'web/splash/splash.json';
 const String _url = '\$FLUTTER_BASE_HREF';

--- a/lib/exceptions.dart
+++ b/lib/exceptions.dart
@@ -1,4 +1,4 @@
-part of animated_native_splash_supported_platform;
+part of 'supported_platform.dart';
 
 ///Expection need to through to our users, For better users experinces
 class _NoConfigFoundException implements Exception {
@@ -49,4 +49,3 @@ class _InvalidNativeFile implements Exception {
         '$message';
   }
 }
-

--- a/lib/supported_platform.dart
+++ b/lib/supported_platform.dart
@@ -23,8 +23,10 @@ part 'templates.dart';
 part 'web.dart';
 
 /// Function that will be called on supported platforms to create the splash screens.
-Future<void> tryCreateSplash() async {
-  var config = _getConfig();
+Future<void> tryCreateSplash({
+  required String? path,
+}) async {
+  var config = _getConfig(path: path);
   await tryCreateSplashByConfig(config);
 }
 
@@ -56,12 +58,26 @@ Future<void> tryCreateSplashByConfig(Map<String, dynamic> config) async {
 }
 
 /// Get config from `pubspec.yaml` or `animated_native_splash.yaml`
-Map<String, dynamic> _getConfig() {
-  // if `animated_native_splash.yaml` exists use it as config file, otherwise use `pubspec.yaml`
-  var filePath = (FileSystemEntity.typeSync('animated_native_splash.yaml') !=
-          FileSystemEntityType.notFound)
-      ? 'animated_native_splash.yaml'
-      : 'pubspec.yaml';
+Map<String, dynamic> _getConfig({
+  required String? path,
+}) {
+  String filePath;
+
+  // if config file was provided via --path argument, check if the file exists
+  if (path != null) {
+    if (File(path).existsSync()) {
+      filePath = path;
+    } else {
+      print('The config file `$path` was not found.');
+      exit(1);
+    }
+  } else {
+    // if `animated_native_splash.yaml` exists use it as config file, otherwise use `pubspec.yaml`
+    filePath = (FileSystemEntity.typeSync('animated_native_splash.yaml') !=
+            FileSystemEntityType.notFound)
+        ? 'animated_native_splash.yaml'
+        : 'pubspec.yaml';
+  }
 
   final file = File(filePath);
   final yamlString = file.readAsStringSync();

--- a/lib/supported_platform.dart
+++ b/lib/supported_platform.dart
@@ -38,14 +38,18 @@ Future<void> tryRemoveSplash() async {
 Future<void> tryCreateSplashByConfig(Map<String, dynamic> config) async {
   String jsonFile = config['jsonFile'] ?? '';
 
-  if (!config.containsKey('android') || config['android']) {
-    await _createAndroidSplash(
+  if (config['android']?["enabled"] ?? true) {
+    return await _createAndroidSplash(
       jsonPath: jsonFile,
     );
   }
-  if (!config.containsKey('web') || config['web']) {
-    await _createWebSplash(path: jsonFile);
+  if (config['web']?["enabled"] ?? true) {
+    return await _createWebSplash(
+      config: config,
+      path: jsonFile,
+    );
   }
+  stderr.writeln('You have disabled both platforms. Nothing was generated!');
 }
 
 /// Get config from `pubspec.yaml` or `animated_native_splash.yaml`

--- a/lib/supported_platform.dart
+++ b/lib/supported_platform.dart
@@ -42,6 +42,8 @@ Future<void> tryCreateSplashByConfig(Map<String, dynamic> config) async {
     await _createAndroidSplash(
       jsonPath: jsonFile,
     );
+  }
+  if (!config.containsKey('web') || config['web']) {
     await _createWebSplash(path: jsonFile);
   }
 }

--- a/lib/supported_platform.dart
+++ b/lib/supported_platform.dart
@@ -39,17 +39,20 @@ Future<void> tryCreateSplashByConfig(Map<String, dynamic> config) async {
   String jsonFile = config['jsonFile'] ?? '';
 
   if (config['android']?["enabled"] ?? true) {
-    return await _createAndroidSplash(
+    await _createAndroidSplash(
       jsonPath: jsonFile,
     );
   }
   if (config['web']?["enabled"] ?? true) {
-    return await _createWebSplash(
+    await _createWebSplash(
       config: config,
       path: jsonFile,
     );
   }
-  stderr.writeln('You have disabled both platforms. Nothing was generated!');
+  if (!(config['android']?["enabled"] ?? true) &&
+      !(config['web']?["enabled"] ?? true)) {
+    stderr.writeln('You have disabled both platforms. Nothing was generated!');
+  }
 }
 
 /// Get config from `pubspec.yaml` or `animated_native_splash.yaml`

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -1,7 +1,7 @@
-part of animated_native_splash_supported_platform;
+part of 'supported_platform.dart';
 
-// Android-related templates
-/// Below is genric template we inject to our project folders
+/// Android-related templates
+/// Below is generic template we inject to our project folders
 
 ///[Andriod SplashView.xml]
 const String _androidSplashViewXml = '''
@@ -207,7 +207,9 @@ String indexTemplate({String? projectName}) => '''
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="example" />
     <link rel="apple-touch-icon" href="icons/Icon-192.png" />
+
     <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+    
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="favicon.png" />
 

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -119,6 +119,7 @@ String _androidStyle = '''
 /// web
 String styleTemplate({
   int fadeOutDuration = 3,
+  String backgroundColor = "#ffffff",
 }) =>
     '''
 .preloader-container {
@@ -133,7 +134,7 @@ String styleTemplate({
 	display: -webkit-box;
 	display: -ms-flexbox;
 	display: flex;
-	background-color: #f1f1f2;
+	background-color: $backgroundColor;
 	-webkit-box-pack: center;
 	-ms-flex-pack: center;
 	justify-content: center;
@@ -250,8 +251,21 @@ String indexTemplate({
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
     <script>
+      var isInitialized = false
+      var isCompleted = false
       let box = document.querySelector("#preloader");
-      function fadeOut() {
+      const animation = document.querySelector("lottie-player");
+
+      animation.addEventListener("complete", () => {
+        isCompleted = true
+        checkSplashAnimation()
+      });
+      animation.addEventListener("loop", () => {
+        isCompleted = true
+        checkSplashAnimation()
+      });
+
+      function fadeOutSplashAnimation() {
         box.classList.add("visuallyhidden");
         box.addEventListener(
           "transitionend",
@@ -265,8 +279,19 @@ String indexTemplate({
           }
         );
       }
-      function remove() {
+
+      function removeSplashAnimation() {
         box.classList.add("hidden");
+      }
+
+      function checkSplashAnimation() {
+        if(!isCompleted) {
+          return;
+        }
+        if(!isInitialized) {
+          return;
+        }
+        ${webFadeOut ? 'fadeOutSplashAnimation();' : 'removeSplashAnimation();'} 
       }
 
       window.addEventListener('load', function(ev) {
@@ -276,10 +301,11 @@ String indexTemplate({
           serviceWorkerVersion: serviceWorkerVersion,
         },
         onEntrypointLoaded: function(engineInitializer) {
-         ${webFadeOut ? 'fadeOut();' : 'remove();'} 
 
-          engineInitializer.initializeEngine().then(function(appRunner) {
-            appRunner.runApp();
+          engineInitializer.initializeEngine().then(async function(appRunner) {
+            await appRunner.runApp();
+            isInitialized = true
+            checkSplashAnimation();
           });
         }
       });

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -187,6 +187,8 @@ String indexTemplate({
   String? projectName,
   bool webLoop = true,
   bool webFadeOut = true,
+  int height = 200,
+  int width = 200,
 }) =>
     '''
 <!DOCTYPE html>
@@ -241,7 +243,7 @@ String indexTemplate({
             src="splash/splash.json"
             background="transparent"
             speed="1"
-            style="width: 400px; height: 400px"${webLoop ? '\nloop' : ''}
+            style="width: ${width}px; height: ${height}px"${webLoop ? '\nloop' : ''}
             autoplay
           ></lottie-player>
         </div>

--- a/lib/unsupported_platform.dart
+++ b/lib/unsupported_platform.dart
@@ -15,7 +15,9 @@ void tryCreateSplashByConfig(Map<String, dynamic> config) async {
 }
 
 /// Function that will be called on unsupported platforms, triggering exception.
-Future<void> tryCreateSplash() async {
+Future<void> tryCreateSplash({
+  required String? path,
+}) async {
   throw UnsupportedError(
       'This package requires dart:io, which is unsupported by this platform.');
 }

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -39,6 +39,7 @@ Future<void> _createStylesheet(
   print('[Web] Creating the style file.');
   stylesheet.writeAsStringSync(styleTemplate(
     fadeOutDuration: config["web"]?["fadeOutDuration"] ?? 3,
+    backgroundColor: config["web"]?["backgroundColor"] ?? "#ffffff",
   ));
 }
 

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -63,6 +63,8 @@ Future<void> _createIndex(
       projectName: _projectName,
       webLoop: config["web"]?["loop"] ?? true,
       webFadeOut: config["web"]?["fadeOut"] ?? true,
+      width: config["web"]?["width"] ?? 200,
+      height: config["web"]?["height"] ?? 200,
     ),
   );
 }

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -1,11 +1,19 @@
 part of 'supported_platform.dart';
 
-Future<void> _createWebSplash({String? path}) async {
+Future<void> _createWebSplash({
+  required Map<String, dynamic> config,
+  String? path,
+}) async {
   if (path!.isNotEmpty) {
     await _deleteWebFile();
-    await _createStylesheet();
+    await _createStylesheet(
+      config,
+    );
     await _saveWebJsonFile(path);
-    await _createIndex(path);
+    await _createIndex(
+      config,
+      path,
+    );
   }
 }
 
@@ -23,18 +31,25 @@ Future<void> _deleteWebFile() async {
 ///
 /// This positions the element and allow us to visible hide
 /// whenever necessary
-Future<void> _createStylesheet() async {
+Future<void> _createStylesheet(
+  Map<String, dynamic> config,
+) async {
   final stylesheet = File(_webRelativeStyleFile);
   stylesheet.createSync(recursive: true);
   print('[Web] Creating the style file.');
-  stylesheet.writeAsStringSync(_style);
+  stylesheet.writeAsStringSync(styleTemplate(
+    fadeOutDuration: config["web"]?["fadeOutDuration"] ?? 3,
+  ));
 }
 
 /// Create index file
 ///
 /// Replace the old index with the new template
 /// This contains the lottie player already set up
-Future<void> _createIndex(path) async {
+Future<void> _createIndex(
+  Map<String, dynamic> config,
+  path,
+) async {
   var jsonfile = File(path).readAsBytesSync();
   if (jsonfile.isEmpty) {
     throw const _NoJsonFileFoundException('No Json file has been added');
@@ -45,6 +60,8 @@ Future<void> _createIndex(path) async {
   index.writeAsStringSync(
     indexTemplate(
       projectName: _projectName,
+      webLoop: config["web"]?["loop"] ?? true,
+      webFadeOut: config["web"]?["fadeOut"] ?? true,
     ),
   );
 }

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -1,4 +1,4 @@
-part of animated_native_splash_supported_platform;
+part of 'supported_platform.dart';
 
 Future<void> _createWebSplash({String? path}) async {
   if (path!.isNotEmpty) {
@@ -11,7 +11,7 @@ Future<void> _createWebSplash({String? path}) async {
 
 /// Deleting the web file
 ///
-/// This allow us to replace the web file with a modiy version,
+/// This allow us to replace the web file with a modified version,
 /// Thus, a version with lottie added or integrated
 Future<void> _deleteWebFile() async {
   final webFile = File(_webIndex);
@@ -22,7 +22,7 @@ Future<void> _deleteWebFile() async {
 /// Create stylesheet
 ///
 /// This positions the element and allow us to visible hide
-/// when ever necessary
+/// whenever necessary
 Future<void> _createStylesheet() async {
   final stylesheet = File(_webRelativeStyleFile);
   stylesheet.createSync(recursive: true);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,120 +5,161 @@ packages:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "20071638cbe4e5964a427cfa0e86dce55d060bc7d82d56f3554095d7239a8765"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.4.2"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.1"
   image:
     dependency: "direct main"
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.1.7"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "3.0.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.12.0"
   path:
     dependency: "direct main"
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "6.0.2"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.4"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: d77dbb9d0b7469d91e42d352334b2b4bbd5cec4379542f1bdb630db368c4d9f6
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   universal_io:
     dependency: "direct main"
     description:
       name: universal_io
-      url: "https://pub.dartlang.org"
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.2.2"
   xml:
     dependency: "direct main"
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
     source: hosted
-    version: "5.3.1"
+    version: "6.5.0"
   yaml:
     dependency: "direct main"
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.2"
+  args:
+    dependency: "direct main"
+    description:
+      name: args
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
   charcode:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
   sdk: ">=2.15.1 <3.0.0"
 
 dependencies:
-  image: ^3.0.2
-  meta: ^1.3.0
-  path: ^1.8.0
-  xml: ^5.1.0
-  yaml: ^3.1.0
-  universal_io: ^2.0.4
+  image: ^4.1.7
+  meta: ^1.10.0
+  path: ^1.8.3
+  xml: ^6.5.0
+  yaml: ^3.1.2
+  universal_io: ^2.2.2
   
 
 dev_dependencies: 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^3.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ">=2.15.1 <3.0.0"
 
 dependencies:
+  args: ^2.4.2
   image: ^4.1.7
   meta: ^1.10.0
   path: ^1.8.3


### PR DESCRIPTION
@rexthecoder This PR includes following:
- updated dependencies
- improved configuration for `android` and web with `enabled` flag. Setting `enabled` to false skips generating splash for the selected platform.
- option to enable/disable loop for the lottie player on the web with `loop` flag
- option to enable/disable fade out animation on the web with `fadeOut` flag. Setting `fadeOut` to false will remove splash lottie without fade out animation
- option to configure fade out duration on the web with `fadeOutDuration` integer variable
- option to set background color on the web with `backgroundColor` string.
- option to set height and width of lottie on the web with `height` and `width` integer variables (in pixels)
- updated example with all added configuration variables
- added option to run package create command with --path argument to the config file

Full example with default values:
```yaml
animated_native_splash:
  jsonFile: assets/loading.json
  android:
    enabled: true
  web:
    enabled: true
    loop: true
    fadeOut: true
    fadeOutDuration: 3
    backgroundColor: "#ffffff"
    height: 200
    width: 200
``` 

Replaced old Flutter web loading code in `index.html` with the new way. Added `load` and `complete` events on the web. Splash animation should work as below:
- if `loop` is enabled, then splash animation will be ensured to complete at least once/one loop cycle (in case Flutter web app loads before full animation cycle finishes).
- if `loop` is disabled, then splash animation will be ensured to complete before removing splash.

Fixes #9 